### PR TITLE
Bump d2l-colors version to fix BSI build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "jquery.ui": "~1.10.3"
   },
   "dependencies": {
-    "d2l-colors": "~2.1.0"
+    "d2l-colors": "^2.2.0"
   }
 }


### PR DESCRIPTION
@dbatiste ?

```shell
Unable to find a suitable version for d2l-colors, please choose one by typing one of the numbers below:
    1) d2l-colors#~2.1.0 which resolved to 2.1.0 and is required by jquery-vui-change-tracking#0.5.3
    2) d2l-colors#^2.1.0 which resolved to 2.2.0 and is required by brightspace-integration, d2l-dropdown#3.0.0, d2l-icons#2.13.0, d2l-image-action#0.5.3, d2l-link#3.1.2, d2l-menu#0.2.3, d2l-navigation#0.14.6, d2l-page-load-progress#1.1.1, d2l-table#0.3.0, jquery-vui-more-less#1.2.1, vui-breadcrumbs#2.1.1, vui-dropdown#0.7.2, vui-input#1.6.3, vui-list#1.1.1, vui-validation#1.1.2
    3) d2l-colors#^2.0.0 which resolved to 2.2.0 and is required by d2l-button#3.0.6, d2l-loading-spinner#4.0.0, d2l-my-courses#0.18.5, vui-field#1.2.0
    4) d2l-colors#^2.2.0 which resolved to 2.2.0 and is required by d2l-typography#5.1.1
```