### PR TITLE
P3 conversion

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,5 @@
   "devDependencies": {
     "jquery": "~2.2.4",
     "jquery.ui": "~1.10.3"
-  },
-  "dependencies": {
-    "d2l-colors": "^3.1.2"
   }
 }

--- a/changeTracking.scss
+++ b/changeTracking.scss
@@ -1,4 +1,4 @@
-@import 'bower_components/d2l-colors/d2l-colors.scss';
+@import 'node_modules/d2l-colors/d2l-colors.scss';
 
 $vui-changed-color: $d2l-color-celestine-plus-2;
 $vui-changed-color-hover: $d2l-color-celestine-plus-2;

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
     "csslint": "^0.10.0",
     "jasmine-core": "^2.4.1",
     "jasmine-dom-matchers": "^0.1.1",
-    "jquery": "~2.2.4",
-    "jquery-ui": "~1.10.3",
     "jshint": "^2.9.1",
     "karma": "^0.13.22",
     "karma-cli": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,16 @@
   },
   "homepage": "https://github.com/Brightspace/jquery-valence-ui-change-tracking",
   "dependencies": {
-    "bower": "^1.7.7"
+    "d2l-colors": "BrightspaceUI/colors#semver:^4"
   },
   "devDependencies": {
+    "bower": "^1.7.7",
     "coveralls": "^2.11.9",
     "csslint": "^0.10.0",
     "jasmine-core": "^2.4.1",
     "jasmine-dom-matchers": "^0.1.1",
+    "jquery": "~2.2.4",
+    "jquery-ui": "~1.10.3",
     "jshint": "^2.9.1",
     "karma": "^0.13.22",
     "karma-cli": "0.1.2",


### PR DESCRIPTION
This simply changes to use d2l-colors from as pulled via npm/node_modules instead of bower, consistent with our web components.  Bower is still being used for JQuery within this project for demo and test.